### PR TITLE
Use correct commit range for GitHub Actions

### DIFF
--- a/ci-info
+++ b/ci-info
@@ -247,8 +247,8 @@ elif [ -n "$GITHUB_HEAD_REF" ] ; then
   # GitHub Actions pull request (no special handling is required for non-PR GitHub Actions jobs).
   CI_IS_PULL_REQUEST=true
   CI_BRANCH_NAME="${GITHUB_HEAD_REF}"
-  CI_COMMIT_RANGE_START=$(git rev-parse "${GITHUB_BASE_REF}")
-  CI_COMMIT_RANGE_END=$(git rev-parse "${GITHUB_HEAD_REF}")
+  CI_COMMIT_RANGE_START=$(git rev-parse "remotes/origin/${CI_COMMIT_RANGE_START}")
+  CI_COMMIT_RANGE_END=$(git rev-parse "remotes/pull/${GITHUB_REF_NAME}")
   CI_COMMIT_RANGE="${CI_COMMIT_RANGE_START}...${CI_COMMIT_RANGE_END}"
 
 else

--- a/ci-info
+++ b/ci-info
@@ -247,7 +247,7 @@ elif [ -n "$GITHUB_HEAD_REF" ] ; then
   # GitHub Actions pull request (no special handling is required for non-PR GitHub Actions jobs).
   CI_IS_PULL_REQUEST=true
   CI_BRANCH_NAME="${GITHUB_HEAD_REF}"
-  CI_COMMIT_RANGE_START=$(git rev-parse "remotes/origin/${CI_COMMIT_RANGE_START}")
+  CI_COMMIT_RANGE_START=$(git rev-parse "remotes/origin/${GITHUB_BASE_REF}")
   CI_COMMIT_RANGE_END=$(git rev-parse "remotes/pull/${GITHUB_REF_NAME}")
   CI_COMMIT_RANGE="${CI_COMMIT_RANGE_START}...${CI_COMMIT_RANGE_END}"
 


### PR DESCRIPTION
#9 Fixes the CI_ORG but not the commit range.

The variable need to be set correctly by adding prefix for Github CI. For example for `EISOP#862`,

Branches in Github CI is 
```
echo   remotes/origin/master
echo   remotes/pull/862/merge
```
We should use the following env variable to set them.
```
GITHUB_BASE_REF=master
GITHUB_REF_NAME=862/merge
```
